### PR TITLE
Update Tested Up To after testing on 5.6 WordPress

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: thundersnow
 Tags: search, site-search, yext, autocomplete, relevant-search, better-search, custom-search, search-by-category, natural-language-search, search-engine
 Requires at least: 4.9.8
-Tested up to: 5.5.1
-Stable tag: 1.0.0
+Tested up to: 5.6
+Stable tag: 1.0.1
 Requires PHP: 7.0
 License: BSD 3-Clause "New" or "Revised" License
 License URI:  https://opensource.org/licenses/BSD-3-Clause


### PR DESCRIPTION
Change readme to reflect that plugin was tested on 5.6. After this is merged, will
move the changes to the SVN repository, create a 1.0.1 folder in the tags/ folder
with the new code (readme changes).

J=SLAP-934
TEST=manual

Test that do_shortcode, shortcode block for [yext_resultspage] and [yext_searchbar]
all work in putting an experience on a page.